### PR TITLE
fixed indentation when importing the Ipascal name interface

### DIFF
--- a/plopTemplates/reactAdapters/src/Component.tsx.hbs
+++ b/plopTemplates/reactAdapters/src/Component.tsx.hbs
@@ -8,7 +8,7 @@
 import React from 'react';
 import '@rhythm-ui/{{kebabCase name}}';
 
-import {I{{pascalCase name}}} from './I{{pascalCase name}}';
+import { I{{pascalCase name}} } from './I{{pascalCase name}}';
 
 export class {{pascalCase name}} extends React.Component<I{{pascalCase name}}> {
 	public render(): JSX.Element {


### PR DESCRIPTION
When using yarn generate component, the react component would not generate via plop due to import error. 