### PR TITLE
Fix CSS style so users can interact with particles behind the hero text

### DIFF
--- a/www/src/css/base.css
+++ b/www/src/css/base.css
@@ -16,6 +16,10 @@ body,
 .hero .hero__content {
 	position: relative;
 	z-index: 2;
+
+	/* Allow users to interact with particles behind the test */
+	pointer-events: none;
+	user-select: none;
 }
 
 .hero p,


### PR DESCRIPTION
Updated the CSS so a user no longer selects the text but interacts with the particles.

Before:
<img width="1346" alt="Screen Shot 2019-07-12 at 2 40 19 pm" src="https://user-images.githubusercontent.com/12177767/61135949-ef7bf600-a4c2-11e9-93f8-391e50d68a3c.png">

After:
<img width="1056" alt="Screen Shot 2019-07-12 at 4 22 17 pm" src="https://user-images.githubusercontent.com/12177767/61135957-f440aa00-a4c2-11e9-9074-da463dd00c51.png">

The button can still be clicked as per usual