### PR TITLE
Chore/update templates for package naming

### DIFF
--- a/plopTemplates/Component/package.json.hbs
+++ b/plopTemplates/Component/package.json.hbs
@@ -1,5 +1,5 @@
 {
-	"name": "@rhythm-ui/{{kebabCase name}}",
+	"name": "@rhythm-ui/{{packageName name}}",
 	"version": "1.0.0",
 	"main": "lib/index.js",
 	"license": "BSD-3-Clause",

--- a/plopTemplates/Component/readme.md.hbs
+++ b/plopTemplates/Component/readme.md.hbs
@@ -1,5 +1,5 @@
 ---
-package: "@rhythm-ui/{{kebabCase name}}"
+package: "@rhythm-ui/{{packageName name}}"
 title: "{{kebabCase name}}"
 ---
 

--- a/plopTemplates/reactAdapters/package.json.hbs
+++ b/plopTemplates/reactAdapters/package.json.hbs
@@ -1,6 +1,6 @@
 
 {
-	"name": "@rhythm-ui/{{kebabCase name}}-react",
+	"name": "@rhythm-ui/{{packageName name}}-react",
 	"version": "1.0.0",
 	"main": "lib/index.js",
 	"scripts": {
@@ -20,7 +20,7 @@
 		"react": "^16.8.6"
 	},
 	"dependencies": {
-		"@rhythm-ui/{{kebabCase name}}": "^1.0.0"
+		"@rhythm-ui/{{packageName name}}": "^1.0.0"
 	},
 	"peerDependencies": {
 		"react": ">= 16"

--- a/plopTemplates/reactAdapters/readme.md.hbs
+++ b/plopTemplates/reactAdapters/readme.md.hbs
@@ -1,6 +1,6 @@
 ---
 package: "@rhythm-ui-react"
-title: "{{kebabCase name}}-react"
+title: "{{packageName name}}-react"
 ---
 
 Readme file for {{kebabCase name}}-react

--- a/plopTemplates/reactAdapters/src/Component.tsx.hbs
+++ b/plopTemplates/reactAdapters/src/Component.tsx.hbs
@@ -6,7 +6,7 @@
 */
 
 import React from 'react';
-import '@rhythm-ui/{{kebabCase name}}';
+import '@rhythm-ui/{{packageName name}}';
 
 import {I{{~pascalCase name~}} } from './I{{pascalCase name}}';
 

--- a/plopTemplates/vueAdapters/package.json.hbs
+++ b/plopTemplates/vueAdapters/package.json.hbs
@@ -1,5 +1,5 @@
 {
-	"name": "@rhythm-ui/{{kebabCase name}}-vue",
+	"name": "@rhythm-ui/{{packageName name}}-vue",
 	"version": "1.0.0",
 	"main": "lib/index.js",
 	"scripts": {
@@ -15,7 +15,7 @@
 		"lib/"
 	],
 	"dependencies": {
-		"@rhythm-ui/{{kebabCase name}}": "^1.0.0",
+		"@rhythm-ui/{{packageName name}}": "^1.0.0",
 		"vue-class-component": "^7.1.0",
 		"vue-property-decorator": "^8.2.1"
 	},

--- a/plopTemplates/vueAdapters/readme.md.hbs
+++ b/plopTemplates/vueAdapters/readme.md.hbs
@@ -1,6 +1,6 @@
 ---
 package: "@rhythm-ui-vue"
-title: "{{kebabCase name}}-vue"
+title: "{{packageName name}}-vue"
 ---
 
 Readme file for {{kebabCase name}}-vue

--- a/plopTemplates/vueAdapters/src/Component.vue.hbs
+++ b/plopTemplates/vueAdapters/src/Component.vue.hbs
@@ -12,7 +12,7 @@
 
 <script lang="ts">
 import {Component, Vue} from 'vue-property-decorator';
-import '@rhythm-ui/{{kebabCase name}}';
+import '@rhythm-ui/{{packageName name}}';
 
 // https://vuejs.org/v2/api/#ignoredElements
 Vue.config.ignoredElements = [

--- a/plopfile.js
+++ b/plopfile.js
@@ -47,19 +47,6 @@ const reactActions = [
 		path: `${REACT_PATH}/tsconfig.json`,
 		templateFile: `${PLOP_REACT}/tsconfig.json.hbs`
 	},
-	{
-		type: 'add',
-		path: `${REACT_PATH}/README.md`,
-		templateFile: `${PLOP_REACT}/readme.md.hbs`
-  	},
-	//append the file into the www package json file at the top of the list
-	{
-		type: 'append',
-		path: 'www/package.json',
-		// Pattern tells plop where in the file to inject the template
-		pattern: `"@mdx-js\/react"\: "\^1\.0\.0-rc\.5",`,
-		template: `		"@rhythm-ui/{{packageName name}}-react": "^1.0.0",`,
-	},
 	// import react adaptor in gatsby site so markdown files will display
 	{
 		type: 'modify',

--- a/plopfile.js
+++ b/plopfile.js
@@ -60,12 +60,6 @@ const reactActions = [
 		pattern: `"@mdx-js\/react"\: "\^1\.0\.0-rc\.5",`,
 		template: `		"@rhythm-ui/{{packageName name}}-react": "^1.0.0",`,
 	},
-	{
-		type: 'append',
-		path: 'www/src/templates/Markdown/Markdown.tsx',
-		pattern: `//Import here//`,
-		template: `import '@rhythm-ui/{{packageName name}}-react';`,
-	},
 	// import react adaptor in gatsby site so markdown files will display
 	{
 		type: 'modify',

--- a/plopfile.js
+++ b/plopfile.js
@@ -53,6 +53,19 @@ const reactActions = [
 		path: 'www/src/templates/Markdown/Markdown.tsx',
 		pattern: /(@@ GENERATOR IMPORT COMPONENT)/g,
 		template: "$1\nimport '@rhythm-ui/{{packageName name}}-react';",
+	},
+	/**
+	 * Adds new dependency to gatsby site package.json
+	 * ASSUMPTIONS for this to work:
+	 * 1. at least one other @rhythm-ui/some-react-component exists in file
+	 * 2. the newly added package is not the last package listed (as it adds a comma 
+	 * 	  and this will not be valid json if added at end)
+	 */
+	{
+		type: 'modify',
+		path: 'www/package.json',
+		pattern: /("@rhythm-ui\/[a-zA-Z-]*": "\^[0-9]*.[0-9]*.[0-9]*",)/g,
+		template: "$1\n\"@rhythm-ui/{{packageName name}}-react\": \"^1.0.0\",",
 	}
 ];
 

--- a/plopfile.js
+++ b/plopfile.js
@@ -58,13 +58,13 @@ const reactActions = [
 		path: 'www/package.json',
 		// Pattern tells plop where in the file to inject the template
 		pattern: `"@mdx-js\/react"\: "\^1\.0\.0-rc\.5",`,
-		template: `		"@rhythm-ui/{{kebabCase name}}-react": "^1.0.0",`,
+		template: `		"@rhythm-ui/{{packageName name}}-react": "^1.0.0",`,
 	},
 	{
 		type: 'append',
 		path: 'www/src/templates/Markdown/Markdown.tsx',
 		pattern: `//Import here//`,
-		template: `import '@rhythm-ui/{{kebabCase name}}-react';`,
+		template: `import '@rhythm-ui/{{packageName name}}-react';`,
 	}
 ];
 
@@ -135,7 +135,11 @@ const checkComponent = () => {
 
 const ensureRui = text => `rui ${text.replace(/Rui/gi, "")}`;
 
+// name comes in as 'rui <component name>' and for a package we just need '< componentname>'
+const packageName = text => text.replace(/rui/gi, "").trim().toLowerCase();
+
 module.exports = plop => {
+	plop.setHelper('packageName', packageName);
     plop.setGenerator('component', {
         description: 'create a new component',
 

--- a/plopfile.js
+++ b/plopfile.js
@@ -51,7 +51,7 @@ const reactActions = [
 		type: 'add',
 		path: `${REACT_PATH}/README.md`,
 		templateFile: `${PLOP_REACT}/readme.md.hbs`
-  },
+  	},
 	//append the file into the www package json file at the top of the list
 	{
 		type: 'append',
@@ -65,6 +65,13 @@ const reactActions = [
 		path: 'www/src/templates/Markdown/Markdown.tsx',
 		pattern: `//Import here//`,
 		template: `import '@rhythm-ui/{{packageName name}}-react';`,
+	},
+	// import react adaptor in gatsby site so markdown files will display
+	{
+		type: 'modify',
+		path: 'www/src/templates/Markdown/Markdown.tsx',
+		pattern: /(@@ GENERATOR IMPORT COMPONENT)/g,
+		template: "$1\nimport '@rhythm-ui/{{packageName name}}-react';",
 	}
 ];
 
@@ -135,8 +142,8 @@ const checkComponent = () => {
 
 const ensureRui = text => `rui ${text.replace(/Rui/gi, "")}`;
 
-// name comes in as 'rui <component name>' and for a package we just need '< componentname>'
-const packageName = text => text.replace(/rui/gi, "").trim().toLowerCase();
+// converts 'rui component name' and for a package we just need 'component-name'
+const packageName = text => text.replace(/rui/gi, "").trim().split(' ').join('-').toLowerCase();
 
 module.exports = plop => {
 	plop.setHelper('packageName', packageName);
@@ -203,16 +210,16 @@ module.exports = plop => {
                     path: `${PATH}/src/index.ts`,
                     templateFile: `${PLOP_PATH}/src/index.ts.hbs`
                 },
-								{
-									type: 'add',
-									path: `${PATH}/tests/{{pascalCase name}}.test.ts`,
-									templateFile: `${PLOP_PATH}/tests/Component.test.ts.hbs`
-								},
-								{
-									type: 'add',
-									path: `${PATH}/tests/tsconfig.json`,
-									templateFile: `${PLOP_PATH}/tests/tsconfig.json.hbs`
-								},
+				{
+					type: 'add',
+					path: `${PATH}/tests/{{pascalCase name}}.test.ts`,
+					templateFile: `${PLOP_PATH}/tests/Component.test.ts.hbs`
+				},
+				{
+					type: 'add',
+					path: `${PATH}/tests/tsconfig.json`,
+					templateFile: `${PLOP_PATH}/tests/tsconfig.json.hbs`
+				}
             ]);
             if (data.adapter === 'React' || data.adapter === 'Both') {
                 actions = actions.concat(reactActions)

--- a/www/src/templates/Markdown/Markdown.tsx
+++ b/www/src/templates/Markdown/Markdown.tsx
@@ -4,7 +4,7 @@ import {graphql} from 'gatsby';
 import {css} from '@emotion/core';
 
 // Import these so markdown files render if they are using these tags
-//Import here//
+// @@ GENERATOR IMPORT COMPONENT
 import '@rhythm-ui/rui-card-react';
 import '@rhythm-ui/button-react';
 import '@rhythm-ui/story-react';


### PR DESCRIPTION
Updates the plop templates to use a new `packageName` helper, this helper removes the 'rui' portion of the name variable to conform to our package naming pattern. 
**Before**:  `@rhythm-ui/rui-expand-collapse`
**After**:  `@rhythm-ui/expand-collapse`

This also updates the react adapter templates to import and add the new package as a dependency to the gatsby site. Previously, the author would have to remember to dig around and add the dependency and import it in the markdown file each time. 

The key goal here is that if a user creates a react adapter, the templating should make it such that all the user has to do is run `yarn` and `yarn start` and everything will work.
