### PR TITLE
Allow projects to define where styles is resolved from

### DIFF
--- a/components/RuiAlert/package.json
+++ b/components/RuiAlert/package.json
@@ -17,10 +17,12 @@
 		"lib/"
 	],
 	"devDependencies": {
+		"@rhythm-ui/styles": "^0.1.0",
+		"lit-element": "^2.1.0",
 		"babel-preset-rhythm-ui": "^0.1.0",
 		"ruidocs": "^0.1.0"
 	},
-	"dependencies": {
+	"peerDependencies": {
 		"@rhythm-ui/styles": "^0.1.0",
 		"lit-element": "^2.1.0"
 	}

--- a/components/RuiBreadcrumbs/package.json
+++ b/components/RuiBreadcrumbs/package.json
@@ -17,10 +17,12 @@
         "lib/"
     ],
     "devDependencies": {
+        "@rhythm-ui/styles": "^0.1.0",
+        "lit-element": "^2.1.0",
         "babel-preset-rhythm-ui": "^0.1.0",
         "ruidocs": "^0.1.0"
     },
-    "dependencies": {
+    "peerDependencies": {
         "@rhythm-ui/styles": "^0.1.0",
         "lit-element": "^2.1.0"
     }

--- a/components/RuiButton/package.json
+++ b/components/RuiButton/package.json
@@ -18,10 +18,12 @@
 		"index.d.ts"
 	],
 	"devDependencies": {
+		"@rhythm-ui/styles": "^0.1.0",
+		"lit-element": "^2.1.0",
 		"babel-preset-rhythm-ui": "^0.1.0",
 		"ruidocs": "^0.1.0"
 	},
-	"dependencies": {
+	"peerDependencies": {
 		"@rhythm-ui/styles": "^0.1.0",
 		"lit-element": "^2.1.0"
 	}

--- a/components/RuiExpandCollapse/package.json
+++ b/components/RuiExpandCollapse/package.json
@@ -17,10 +17,12 @@
 		"lib/"
 	],
 	"devDependencies": {
+		"@rhythm-ui/styles": "^0.1.0",
+		"lit-element": "^2.1.0",
 		"babel-preset-rhythm-ui": "^0.1.0",
 		"ruidocs": "^0.1.0"
 	},
-	"dependencies": {
+	"peerDependencies": {
 		"@rhythm-ui/styles": "^0.1.0",
 		"lit-element": "^2.1.0"
 	}

--- a/components/RuiGrid/package.json
+++ b/components/RuiGrid/package.json
@@ -17,10 +17,12 @@
 		"lib/"
 	],
 	"devDependencies": {
+		"@rhythm-ui/styles": "^0.1.0",
+		"lit-element": "^2.1.0",
 		"babel-preset-rhythm-ui": "^0.1.0",
 		"ruidocs": "^0.1.0"
 	},
-	"dependencies": {
+	"peerDependencies": {
 		"@rhythm-ui/styles": "^0.1.0",
 		"lit-element": "^2.1.0"
 	}

--- a/components/RuiHeroBanner/package.json
+++ b/components/RuiHeroBanner/package.json
@@ -17,10 +17,12 @@
 		"lib/"
 	],
 	"devDependencies": {
+		"@rhythm-ui/styles": "^0.1.0",
+		"lit-element": "^2.1.0",
 		"babel-preset-rhythm-ui": "^0.1.0",
 		"ruidocs": "^0.1.0"
 	},
-	"dependencies": {
+	"peerDependencies": {
 		"@rhythm-ui/styles": "^0.1.0",
 		"lit-element": "^2.1.0"
 	}

--- a/components/RuiIcon/package.json
+++ b/components/RuiIcon/package.json
@@ -17,10 +17,12 @@
 		"lib/"
 	],
 	"devDependencies": {
+		"@rhythm-ui/styles": "^0.1.0",
+		"lit-element": "^2.1.0",
 		"babel-preset-rhythm-ui": "^0.1.0",
 		"ruidocs": "^0.1.0"
 	},
-	"dependencies": {
+	"peerDependencies": {
 		"@rhythm-ui/styles": "^0.1.0",
 		"lit-element": "^2.1.0"
 	}

--- a/components/RuiLayout/package.json
+++ b/components/RuiLayout/package.json
@@ -17,10 +17,12 @@
 		"lib/"
 	],
 	"devDependencies": {
+		"@rhythm-ui/styles": "^0.1.0",
+		"lit-element": "^2.1.0",
 		"babel-preset-rhythm-ui": "^0.1.0",
 		"ruidocs": "^0.1.0"
 	},
-	"dependencies": {
+	"peerDependencies": {
 		"@rhythm-ui/styles": "^0.1.0",
 		"lit-element": "^2.1.0"
 	}

--- a/components/RuiPagination/package.json
+++ b/components/RuiPagination/package.json
@@ -17,10 +17,12 @@
 		"lib/"
 	],
 	"devDependencies": {
+		"@rhythm-ui/styles": "^0.1.0",
+		"lit-element": "^2.1.0",
 		"babel-preset-rhythm-ui": "^0.1.0",
 		"ruidocs": "^0.1.0"
 	},
-	"dependencies": {
+	"peerDependencies": {
 		"@rhythm-ui/styles": "^0.1.0",
 		"lit-element": "^2.1.0"
 	}

--- a/components/RuiRichText/package.json
+++ b/components/RuiRichText/package.json
@@ -17,10 +17,12 @@
 		"lib/"
 	],
 	"devDependencies": {
+		"@rhythm-ui/styles": "^0.1.0",
+		"lit-element": "^2.1.0",
 		"babel-preset-rhythm-ui": "^0.1.0",
 		"ruidocs": "^0.1.0"
 	},
-	"dependencies": {
+	"peerDependencies": {
 		"@rhythm-ui/styles": "^0.1.0",
 		"lit-element": "^2.1.0"
 	}

--- a/components/RuiScrollTo/package.json
+++ b/components/RuiScrollTo/package.json
@@ -17,12 +17,16 @@
 		"lib/"
 	],
 	"devDependencies": {
+		"@rhythm-ui/styles": "^0.1.0",
+		"lit-element": "^2.1.0",
 		"babel-preset-rhythm-ui": "^0.1.0",
 		"ruidocs": "^0.1.0"
 	},
 	"dependencies": {
-		"@rhythm-ui/styles": "^0.1.0",
-		"lit-element": "^2.1.0",
 		"smoothscroll-polyfill": "^0.4.4"
+	},
+	"peerDependencies": {
+		"@rhythm-ui/styles": "^0.1.0",
+		"lit-element": "^2.1.0"
 	}
 }

--- a/components/RuiSkipLinks/package.json
+++ b/components/RuiSkipLinks/package.json
@@ -17,10 +17,12 @@
 		"lib/"
 	],
 	"devDependencies": {
+		"@rhythm-ui/styles": "^0.1.0",
+		"lit-element": "^2.1.0",
 		"babel-preset-rhythm-ui": "^0.1.0",
 		"ruidocs": "^0.1.0"
 	},
-	"dependencies": {
+	"peerDependencies": {
 		"@rhythm-ui/styles": "^0.1.0",
 		"lit-element": "^2.1.0"
 	}

--- a/components/RuiStory/package.json
+++ b/components/RuiStory/package.json
@@ -17,10 +17,12 @@
 		"lib/"
 	],
 	"devDependencies": {
+		"@rhythm-ui/styles": "^0.1.0",
+		"lit-element": "^2.1.0",
 		"babel-preset-rhythm-ui": "^0.1.0",
 		"ruidocs": "^0.1.0"
 	},
-	"dependencies": {
+	"peerDependencies": {
 		"@rhythm-ui/styles": "^0.1.0",
 		"lit-element": "^2.1.0"
 	}


### PR DESCRIPTION
This PR addresses an issue when running the canary version of RUI and resolving the styles component. It will allow the project to define how styles is defined.

![MicrosoftTeams-image](https://user-images.githubusercontent.com/11452925/65403967-cdcfb100-de19-11e9-8852-25cf63ed3296.png)
