### PR TITLE
Update docs and styling for rui-breadcrumbs

### DIFF
--- a/components/RuiBreadcrumbs/readme.md
+++ b/components/RuiBreadcrumbs/readme.md
@@ -60,19 +60,8 @@ Events triggered by actions inside the component.
 
 ## Styling
 
-> The `<a />` tag color is not styled by default and will inherit from your base styles.
+> Styles are automatically applied to the anchor element child. These styles may be overriden by targeting the anchor element through your own stylesheets.
 
-Use the `RuiBreadcrumbs` key to apply any custom css.
-
-```js
-import {css, createShadowStyles} from '@rhythm-ui/styles';
-
-createShadowStyles({
-	RuiBreadcrumbs: css`
-		/* Your custom css */
-	`,
-});
-```
 
 To extend and override templates or methods
 

--- a/components/RuiBreadcrumbs/src/RuiBreadcrumbs.css.ts
+++ b/components/RuiBreadcrumbs/src/RuiBreadcrumbs.css.ts
@@ -19,7 +19,7 @@ export const variables = css`
 		/**
 		 * @variable Separator color
 		 */
-		--rui-breadcrumbs__separator-color: inherit;
+		--rui-breadcrumbs__separator-color: #5F5F5F;
 
 		/**
 		 * @variable Separator background
@@ -35,36 +35,6 @@ export const variables = css`
 		 * @variable Expand button padding
 		 */
 		--rui-breadcrumbs__expand-btn-padding: 0 4px;
-
-		/**
-		 * @variable Crumbs font weight
-		 */
-		--rui-breadcrumbs__font-weight: normal;
-
-		/**
-		 * @variable Crumb text decoration
-		 */
-		--rui-breadcrumbs__text-decoration: none;
-
-		/**
-		 * @variable Crumb text decoration on hover
-		 */
-		--rui-breadcrumbs__text-decoration-hover: underline;
-
-		/**
-		 * @variable Current/Active Crumb font weight
-		 */
-		--rui-breadcrumbs__current-font-weight: var(--rui-breadcrumbs__font-weight);
-
-		/**
-		 * @variable Current/Active Crumb color
-		 */
-		--rui-breadcrumbs__current-color: inherit;
-
-		/**
-		 * @variable Current/Active Crumb color on hover
-		 */
-		--rui-breadcrumbs__current-color-hover: inherit;
 	}
     `;
 
@@ -86,7 +56,7 @@ export const layout = css`
 		display: inline-block;
 	}
 
-	.crumbs li:after {
+	.crumbs li::after {
 		display: inline-block;
 		padding: var(--rui-breadcrumbs__separator-padding);
 		color: var(--rui-breadcrumbs__separator-color);
@@ -94,26 +64,30 @@ export const layout = css`
 		background: var(--rui-breadcrumbs__separator-background);
 	}
 
-	.crumbs li:last-child:after {
+	.crumbs li:last-child::after {
 		display: none;
 	}
 
-	.crumbs li a {
-		font-weight: var(--rui-breadcrumbs__font-weight);
-		text-decoration: var(--rui-breadcrumbs__text-decoration);
+	::slotted(a) {
+		padding: 4px;
+		color: #208834;
+		text-decoration: none;
 	}
 
-	.crumbs li a:hover {
-		text-decoration: var(--rui-breadcrumbs__text-decoration-hover);
+	li:last-child ::slotted(a) {
+		color: #5F5F5F;
 	}
 
-	.crumbs li:last-child a {
-		font-weight: var(--rui-breadcrumbs__current-font-weight);
-		color: var(--rui-breadcrumbs__current-color);
+	::slotted(a:focus) {
+		outline: currentColor solid 1px;
 	}
 
-	.crumbs li:last-child a:hover {
-		color: var(--rui-breadcrumbs__current-color-hover);
+	::slotted(a:hover) {
+		text-decoration: underline;
+	}
+
+	li:last-child ::slotted(a:hover) {
+		text-decoration: none;
 	}
 
 	.expand-btn {

--- a/components/RuiBreadcrumbs/src/RuiBreadcrumbs.ts
+++ b/components/RuiBreadcrumbs/src/RuiBreadcrumbs.ts
@@ -63,16 +63,21 @@ export class RuiBreadcrumbs extends LitElement {
 	 * Connected callback
 	*/
 	public connectedCallback() {
-		super.connectedCallback()
+		super.connectedCallback();
 
 		this._crumbs = 
 			[...this.children]
 			.map((c, i) => {
+				c.slot = i;
+
 				// A11y. Set the aria-current on the last element if not done so
 				if (i === this.children.length - 1 && !c.getAttribute('aria-current')) {
 					c.setAttribute('aria-current', 'page');
 				}
-				return html`<li>${c}</li>`;
+				return html`
+					<li>
+						<slot name=${i}></slot>
+					</li>`;
 			});
 	}
 

--- a/components/RuiBreadcrumbs/tests/RuiBreadcrumbs.test.ts
+++ b/components/RuiBreadcrumbs/tests/RuiBreadcrumbs.test.ts
@@ -1,0 +1,64 @@
+/* eslint @typescript-eslint/explicit-function-return-type: 0 */
+/**
+* Copyright Deloitte Digital 2019
+*
+* This source code is licensed under the BSD-3-Clause license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+import '../src';
+import TestUtils from '../../../TestUtils';
+
+describe('RuiBreadcrumbs', () => {
+
+	it('Renders', async () => {
+		const element = await TestUtils.render('rui-breadcrumbs', {}, '');
+		expect(element).toBeDefined();
+		expect(element.shadowRoot).toBeDefined();
+	});
+
+	it('Generates a list item element per each anchor element child', async () => {
+		const element = await TestUtils.render('rui-breadcrumbs', {}, `
+			<a href="/">Link 1</a>
+			<a href="/">Link 2</a>
+			<a href="/">Link 3</a>
+			<a href="/">Link 4</a>
+			<a href="/">Link 5</a>
+		`);
+
+		const numberaOfListItems = element.shadowRoot.querySelectorAll('li').length;
+		expect(numberaOfListItems).toBe(5);
+	});
+
+	it('Marks the last anchor element child as a link to the current page', async () => {
+		let element = await TestUtils.render('rui-breadcrumbs', {}, `
+			<a href="/" class="last">Link 1</a>
+		`);
+
+		const current = element.querySelector('.last');
+		let attributeValue = current.getAttribute('aria-current');
+		expect(attributeValue).toBe('page');
+
+		element = await TestUtils.render('rui-breadcrumbs', {}, `
+			<a href="/">Link 1</a>
+			<a href="/">Link 2</a>
+			<a href="/" class="last">Link 3</a>
+		`);
+
+		attributeValue = current.getAttribute('aria-current');
+		expect(attributeValue).toBe('page');
+	});
+
+	it('Shows a maximum number of anchor element children if specified', async () => {
+		const element = await TestUtils.render('rui-breadcrumbs', {max: 2}, `
+			<a href="/">Link 1</a>
+			<a href="/">Link 2</a>
+			<a href="/">Link 3</a>
+			<a href="/">Link 4</a>
+			<a href="/">Link 5</a>
+		`);
+
+		const numberaOfListItems = element.shadowRoot.querySelectorAll('li').length;
+		expect(numberaOfListItems).toBe(3);
+	});
+});

--- a/components/RuiBreadcrumbs/tests/tsconfig.json
+++ b/components/RuiBreadcrumbs/tests/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"extends": "../../../tsconfig.json",
+	"compilerOptions": {
+		"strictNullChecks": false // These will break tests anyway
+	}
+}

--- a/www/src/components/Layout/Layout.tsx
+++ b/www/src/components/Layout/Layout.tsx
@@ -81,7 +81,7 @@ export const Layout: React.SFC<IProps> = ({nav, breadcrumbs, tocs, editPath, mar
 						<div className="l-7">
 							<RuiRichText>
 								{breadcrumbs &&
-									<RuiBreadcrumbs>
+									<RuiBreadcrumbs class="breadcrumbs">
 										{breadcrumbs.map(b => <a>{b.label}</a>)}
 										<a href="#">{title}</a>
 									</RuiBreadcrumbs>

--- a/www/src/css/typography.css
+++ b/www/src/css/typography.css
@@ -73,21 +73,11 @@ code {
 	background: rgba(255, 229, 100, 0.3);
 }
 
-a,
-a:active,
-a:visited {
-	color: #6C5CE7;
-}
-
-a:hover {
-	color: #512DA8;
-}
-
-rui-breadcrumbs a {
+.breadcrumbs a {
 	text-decoration: none;
 	color: #111 !important;
 }
 
-rui-breadcrumbs a:hover {
+.breadcrumbs a:hover {
 	text-decoration: underline;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12542,7 +12542,7 @@ lodash@4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
-lodash@^4.0.1, lodash@^4.11.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
+lodash@^4.0.1, lodash@^4.11.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
- Add unit tests.
- Add default styling.
- Modify stylesheet that, as a side effect, overrode the default styles for this component on the readme page. 
- Reduce the number of CSS custom properties (CSS variables) associated with this component.
- Solve issue with anchor element children not being able to be styled as they got pulled into this component's shadow DOM.
- Update readme file.
