### PR TITLE
[Bugfix] Prevent RuiIcon mask from repeating

### DIFF
--- a/components/RuiIcon/src/RuiIcon.css.ts
+++ b/components/RuiIcon/src/RuiIcon.css.ts
@@ -53,6 +53,9 @@ export const layout = css`
 		mask-position: center;
 		/* stylelint-disable-next-line property-no-vendor-prefix */
 		-webkit-mask-position: center;
+		mask-repeat: no-repeat;
+		/* stylelint-disable-next-line property-no-vendor-prefix */
+		-webkit-mask-repeat: no-repeat;
 	}
 	
 	/* stylelint-disable-next-line */


### PR DESCRIPTION
Added missing no-repeat rule for `-webkit-mask` to prevent icons clipping their container if the aspect ratio doesn't match perfectly.